### PR TITLE
Update ngrok proxy port to point to 6066

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "ngrok": "npm run proxy",
-    "proxy": "ngrok http 3000",
+    "proxy": "ngrok http 6066",
     "start": "npm run dev",
     "compile": "node_modules/.bin/babel src --out-dir dist",
     "p": "cross-env NODE_ENV=production node -r @babel/register bin/rcec.js example-configs/demo-config.js",


### PR DESCRIPTION
In https://github.com/ringcentral/engage-digital-source-sdk-js/blob/master/.env.sample the port for the server is set to 6066 but the ngrok proxy is configured to point to 3000 which is not compatible